### PR TITLE
Load landmask check shapefile only once for mutliple timesteps

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,14 @@ hemisphere).
 
 ## Usage
 
-Pull the repository and build a `priima` docker image by executing
+Pull the repository. Submodules need to be installed either by appending
+`--recurse-submodules` to the `git clone` command or by running
+
+```
+git submodule update --init --recursive
+```
+
+Then build a `priima` docker image by executing
 
 ```
 docker compose build

--- a/devops/bin/create_landmask_shapefiles.py
+++ b/devops/bin/create_landmask_shapefiles.py
@@ -37,6 +37,7 @@ def filter_shapefile_by_latitude(
     else:
         gdf_filtered = gdf[gdf.geometry.centroid.y < latitude_threshold]
 
+    gdf_filtered.loc[:, 'geometry'] = gdf_filtered['geometry'].make_valid()
     gdf_filtered.to_file(output_shapefile)
 
 if __name__ == "__main__":

--- a/priima/shapefile.py
+++ b/priima/shapefile.py
@@ -44,9 +44,10 @@ class Shapefile:
                            f"reference information. File: {path}")
                 raise ValueError(err_msg)
 
-            for shapefile_record in fh:
-                shape = shapely.geometry.shape(shapefile_record["geometry"])
-                self.geometries.append(make_valid(shape))
+            self.geometries = [
+                shapely.geometry.shape(shp_record["geometry"])
+                for shp_record in fh
+            ]
 
         # Create an STRtree for fast queries like "is point covered by"
         self.strtree = STRtree(geoms=self.geometries)

--- a/priima/warp_forecast.py
+++ b/priima/warp_forecast.py
@@ -28,7 +28,6 @@ from pyproj import Proj, transform
 from priima.config import Config
 from priima.geo_tools import get_half_region_size
 from priima.projection import get_projection, get_projection_epsg
-from priima.shapefile import Shapefile
 
 
 def reproject2roi(filename):
@@ -107,7 +106,7 @@ def compute_displacement(drift, forecast_step):
     return drift_in_meters
 
 
-def update_point_location(gcp_list_dynamic, drift):
+def update_point_location(gcp_list_dynamic, drift, landmask):
     gcp_list_updated = []
     if isinstance(drift[0], list):
         udrift = np.array(drift[0])
@@ -120,11 +119,6 @@ def update_point_location(gcp_list_dynamic, drift):
     ind = 0
     outProj = get_projection()
     inProj = Proj(init='epsg:4326')
-
-    if Config.instance().center[0] > 0:
-        landmask = Shapefile(path="shapefiles/arctic_landmask.shp")
-    else:
-        landmask = Shapefile(path="shapefiles/antarctic_landmask.shp")
 
     for gcp in gcp_list_dynamic:
         drift_point = [udrift[ind], vdrift[ind]]


### PR DESCRIPTION
By loading the shapefile only once we save a bunch of time (the more timesteps calculated, the more time we save). Timing improved from 3.5 minutes to 2 minutes for just 3 timesteps.