### PR TITLE
Implement "number of GCPs" parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ Furthermore, the following parameters are passed:
   the ice drift
 
 There are some other parameters possible for fine tuning results:
-* `--gcp-separation` the distance between the ground control points to warp the
-  image, in pixels. The default is `1000`.
+* `--num-gcps` the number of ground control points which can be `4`, `9`,
+  `16`, `25` or `36`. The default is `4`.
 * `--output-resolution` the image resolution of the output image, default is
   `100`.
 * `--gtif-out` to output images in GeoTiff format instead of cloud-optimized

--- a/priima/config.py
+++ b/priima/config.py
@@ -47,8 +47,8 @@ class Config:
                 help='Model from which to derive the ice drift'
             )
             parser.add_argument(
-                '--gcp-separation', default=5000, type=int,
-                help='Space between ground control points in pixels'
+                '--num-gcps', default=4, type=int, choices=[4, 9, 16, 25, 36],
+                help='Number of ground control points'
             )
             parser.add_argument(
                 '--output-resolution', default=100, type=int,

--- a/priima/config.py
+++ b/priima/config.py
@@ -51,7 +51,7 @@ class Config:
                 help='Number of ground control points'
             )
             parser.add_argument(
-                '--output-resolution', default=100, type=int,
+                '--output-resolution', default=200, type=int,
                 help="Resolution of the output images"
             )
             parser.add_argument(

--- a/priima/inverse_gcps_recipe.py
+++ b/priima/inverse_gcps_recipe.py
@@ -18,6 +18,8 @@ based on a known projection, image dimension and pixel size
 Author: Stefan Hendricks
 """
 
+import math
+
 import numpy as np
 from osgeo import osr
 from pyproj import Proj
@@ -64,14 +66,16 @@ def inversion_gcps_recipe(ds, proj):
     extent = (x_min, y_min,
               x_min+x_size*ds.RasterXSize, y_min+y_size*ds.RasterYSize)
 
+    segments_per_side = math.sqrt(Config.instance().num_gcps) - 1
+    x_pix_separation = math.ceil(ds.RasterXSize / segments_per_side)
+    y_pix_separation = math.ceil(ds.RasterYSize / segments_per_side)
+
     # Step1: Compute the projection coordinates for each pixel
 
     # 1.a: Start with creating indices (lets say for every 250 pixels)
     # and make sure to have starting and ending pixels
-    x_ind = np.arange(
-        0, image_dimensions[0]+1, Config.instance().gcp_separation)
-    y_ind = np.arange(
-        0, image_dimensions[1]+1, Config.instance().gcp_separation)
+    x_ind = np.arange(0, image_dimensions[0]+1, x_pix_separation)
+    y_ind = np.arange(0, image_dimensions[1]+1, y_pix_separation)
 
     if x_ind[-1] != image_dimensions[0]:
         x_ind = np.append(x_ind, image_dimensions[0])

--- a/priima/preprocessing.py
+++ b/priima/preprocessing.py
@@ -97,6 +97,12 @@ def warp_image(
         out_img = tps.warpImage(imbuffer)
         print(f'Warping with FastCast took {time.time() - t} s')
 
+    if out_img.max() == 0:
+        err_msg = (
+            "TPS point fit invalid. Try decreasing the image resolution "
+            "(via --output-resolution)")
+        raise ValueError(err_msg)
+
     write_geotiff(
         forecast_step=forecast_step, image_path=image_path,
         raster_data=out_img, pixels_drift=pixels_drift,

--- a/priima/warp_forecast.py
+++ b/priima/warp_forecast.py
@@ -263,11 +263,13 @@ def create_transformation_matrix(dataset, gcp_list_initial, gcp_list_ending):
         starting_pos_test.append((1*gcp.GCPPixel, gcp.GCPLine))
         ending_pos_test.append((1*gcp_end.GCPPixel, gcp_end.GCPLine))
 
-    xpix_initial = list(
-        range(0, dataset.RasterXSize, Config.instance().gcp_separation))
+    segments_per_side = math.sqrt(Config.instance().num_gcps) - 1
+    x_pix_separation = math.ceil(dataset.RasterXSize / segments_per_side)
+    y_pix_separation = math.ceil(dataset.RasterYSize / segments_per_side)
+
+    xpix_initial = list(range(0, dataset.RasterXSize, x_pix_separation))
     xpix_initial.append(dataset.RasterXSize)
-    ypix_initial = list(
-        range(0, dataset.RasterYSize, Config.instance().gcp_separation))
+    ypix_initial = list(range(0, dataset.RasterYSize, y_pix_separation))
     ypix_initial.append(dataset.RasterXSize)
     starting_pos = [(xi, yi) for xi in xpix_initial for yi in ypix_initial]
 


### PR DESCRIPTION
* Replace `--gcp-separation` parameter with `--num-gcps` to give a specific number of GCPs instead of the distance between them in pixels. Possible (for now) are 4, 9, 16, 25 and 36. Larger values might lead to way too large computation times. Only these numbers are available as the GCP setting can only handle a setting with equal distance along each side.
* Raise error upon a botched TPS calculation. This has been an issue for a long time. The calculation should fail in case a 0-array is returned.
* Change the default resolution in order to have stable results for increased number of GCPs. Let's test this to see if it is enough.